### PR TITLE
feat: custom stopwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ stylecloud --file_path constitution.txt --icon_name 'fas fa-dog' --palette color
 
 You can find more examples of styleclouds, including how to make styleclouds from Twitter and Reddit data, in the [stylecloud-examples](https://github.com/minimaxir/stylecloud-examples) repo.
 
+In order to deal with different languages or simply add list of custom stopwords it is possible to pass a list contained in a string as parameter like so :
+
+```sh
+stylecloud --file_path constitution.txt --custom_words "[thereof, may, state, united states]"
+```
+
+For more control it would of course be most ideal to define the list in code since if one is defining stopwords for another language these lists can get long. In that case simply pass in the list as argument to the function
+
+```python
+import stylecloud
+my_long_list = [thereof, may, state, united states]
+
+stylecloud.gen_stylecloud(file_path=constitution.txt, custom_words=my_long_list)
+```
+Good ressources for stopwords in other languages are the [stop-words python package](https://github.com/Alir3z4/python-stop-words) which gives you python lists directly. Or as JSON arrays this list of [iso stopword collections](https://github.com/stopwords-iso/stopwords-iso).
+
 ### Helpful Parameters
 
 These parameters are valid for both the Python function and the CLI (you can use `stylecloud -h` to get this information as well).
@@ -78,6 +94,7 @@ These parameters are valid for both the Python function and the CLI (you can use
 * max_font_size: Maximum font size in the stylecloud. [default: `200`]
 * max_words: Maximum number of words to include in the stylecloud. [default: `2000`]
 * stopwords: Boolean to filter out common stopwords. [default: `True`]
+* custom_stopwords: list of custom stopwords. e.g: For other languages than english [default: `STOPWORDS`]
 * output_name: Output file name of the stylecloud. [default: `stylecloud.png`]
 * font_path: Path to .ttf file for font to use in stylecloud. [default: uses included Staatliches font]
 * random_state: Controls random state of words and colors.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For more control it would of course be most ideal to define the list in code sin
 
 ```python
 import stylecloud
-my_long_list = [thereof, may, state, united states]
+my_long_list = ["thereof", "may", "state", "united states"]
 
 stylecloud.gen_stylecloud(file_path=constitution.txt, custom_words=my_long_list)
 ```

--- a/stylecloud/stylecloud.py
+++ b/stylecloud/stylecloud.py
@@ -162,7 +162,7 @@ def gen_stylecloud(text=None,
     wc = WordCloud(background_color=background_color,
                    font_path=font_path,
                    max_words=max_words, mask=mask_array,
-                   stopwords=STOPWORDS if stopwords else None,
+                   stopwords=stopwords if stopwords else STOPWORDS,
                    max_font_size=max_font_size, random_state=random_state)
 
     # generate word cloud

--- a/stylecloud/stylecloud.py
+++ b/stylecloud/stylecloud.py
@@ -110,6 +110,7 @@ def gen_stylecloud(text=None,
                    max_font_size=200,
                    max_words=2000,
                    stopwords=True,
+                   custom_stopwords=STOPWORDS,
                    icon_dir='.temp',
                    output_name='stylecloud.png',
                    gradient=None,
@@ -126,6 +127,7 @@ def gen_stylecloud(text=None,
     :param max_font_size: Maximum font size in the stylecloud.
     :param max_words: Maximum number of words to include in the stylecloud.
     :param stopwords: Boolean to filter out common stopwords.
+    :param custom_stopwords: list of custom stopwords.
     :param icon_dir: Temp directory to store the icon mask image.
     :param output_name: Output file name of the stylecloud.
     :param gradient: Direction of gradient. (if not None, will use gradient)
@@ -162,7 +164,7 @@ def gen_stylecloud(text=None,
     wc = WordCloud(background_color=background_color,
                    font_path=font_path,
                    max_words=max_words, mask=mask_array,
-                   stopwords=stopwords if stopwords else STOPWORDS,
+                   stopwords=custom_stopwords if stopwords else None,
                    max_font_size=max_font_size, random_state=random_state)
 
     # generate word cloud


### PR DESCRIPTION
I know this edit is tiny and if this was the desired functionality you would have implemented it. I think this change makes it really simple to add in personalized lists of stopwords. This stems from my personal use case where I needed to generate a cloud for french text and the standard stopword list was of course not cutting it.